### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: 'build-test'
+permissions:
+  contents: read
 on: # rebuild any PRs and main branch changes
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/amilcarlucas/mypy-github-action/security/code-scanning/6](https://github.com/amilcarlucas/mypy-github-action/security/code-scanning/6)

The recommended fix is to add a `permissions:` block at the root of the workflow YAML (`.github/workflows/test.yml`) to explicitly set minimal required permissions for the GITHUB_TOKEN. This should be set as `contents: read` to grant the lowest privilege necessary unless the workflow or specific jobs need to do more (e.g., create pull-request comments). In this case, neither job appears to require elevated permissions, so `contents: read` is sufficient. Add the block after the `name:` line and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
